### PR TITLE
Added dynamic HTTP request body based on templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Options:
   -T  Content-type, defaults to "text/html".
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
+  -X  Dynamic HTTP request body generation from template.
+      For example, {{int}} will be replaced with an incrementing integer from 0 to n;
+      {{datetime}} with current RFC3339 time.
   -h2 Enable HTTP/2.
 
   -host	HTTP Host header.

--- a/hey.go
+++ b/hey.go
@@ -29,7 +29,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rakyll/hey/requester"
+	"github.com/segmentio/hey/requester" // XXX
 )
 
 const (
@@ -59,6 +59,7 @@ var (
 	h2   = flag.Bool("h2", false, "")
 	cpus = flag.Int("cpus", runtime.GOMAXPROCS(-1), "")
 
+	enableRenderer     = flag.Bool("X", false, "")
 	disableCompression = flag.Bool("disable-compression", false, "")
 	disableKeepAlives  = flag.Bool("disable-keepalive", false, "")
 	disableRedirects   = flag.Bool("disable-redirects", false, "")
@@ -89,6 +90,9 @@ Options:
   -T  Content-type, defaults to "text/html".
   -a  Basic authentication, username:password.
   -x  HTTP Proxy address as host:port.
+  -X  Dynamic HTTP request body generation from template.
+      For example, {{int}} will be replaced with an incrementing integer from 0 to n;
+      {{datetime}} with current RFC3339 time.
   -h2 Enable HTTP/2.
 
   -host	HTTP Host header.
@@ -197,7 +201,6 @@ func main() {
 	if err != nil {
 		usageAndExit(err.Error())
 	}
-	req.ContentLength = int64(len(bodyAll))
 
 	// set host header if set
 	if *hostHeader != "" {
@@ -224,6 +227,7 @@ func main() {
 		C:                  conc,
 		QPS:                q,
 		Timeout:            *t,
+		EnableRenderer:     *enableRenderer,
 		DisableCompression: *disableCompression,
 		DisableKeepAlives:  *disableKeepAlives,
 		DisableRedirects:   *disableRedirects,

--- a/requester/renderer.go
+++ b/requester/renderer.go
@@ -1,0 +1,40 @@
+package requester
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+type renderer struct {
+	results  chan []byte
+	handlers map[string]func(id int) string
+}
+
+func newRenderer(results chan []byte) *renderer {
+	return &renderer{
+		results: results,
+		handlers: map[string]func(int) string{
+			"int": func(i int) string {
+				return strconv.Itoa(i)
+			},
+			"datetime": func(i int) string {
+				return time.Now().Format(time.RFC3339Nano)
+			},
+		},
+	}
+}
+
+func runRenderer(r *renderer, template []byte, n int) {
+	for i := 0; i < n; i++ {
+		r.results <- r.Render(template, i)
+	}
+}
+
+func (r *renderer) Render(template []byte, i int) []byte {
+	body := string(template)
+	for key, generator := range r.handlers {
+		body = strings.Replace(body, "{{"+key+"}}", generator(i), -1)
+	}
+	return []byte(body)
+}

--- a/requester/renderer_test.go
+++ b/requester/renderer_test.go
@@ -1,0 +1,63 @@
+package requester
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRenderer(t *testing.T) {
+	var bitmap int32
+	var mux sync.Mutex
+	template := "{{int}} foo {{datetime}} bar {{int}}"
+	start := time.Now()
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		body, _ := ioutil.ReadAll(r.Body)
+		words := strings.Fields(string(body))
+		if len(words) != 5 {
+			t.Errorf("Expected to have 5 words, found %d", len(words))
+		}
+		if words[0] != words[4] {
+			t.Errorf("Expected int to be the same, found %s %s", words[0], words[4])
+		}
+		if words[1]+words[3] != "foobar" {
+			t.Errorf("Expected to have foo bar, found %s %s", words[1], words[3])
+		}
+
+		mux.Lock()
+		defer mux.Unlock()
+
+		renderTime, _ := time.Parse(time.RFC3339Nano, words[2])
+		if renderTime.Before(start) || renderTime.After(time.Now()) {
+			t.Errorf("Expected time to be recent %v, found %s", start, words[2])
+		}
+
+		i, _ := strconv.Atoi(words[0])
+		if bitmap&(1<<uint(i)) != 0 {
+			t.Errorf("Expected to have foo bar, found %s %s", words[1], words[3])
+		}
+		bitmap |= (1 << uint(i))
+	}
+	server := httptest.NewServer(http.HandlerFunc(handler))
+	defer server.Close()
+
+	req, _ := http.NewRequest("POST", server.URL, nil)
+	w := &Work{
+		Request:        req,
+		RequestBody:    []byte(template),
+		EnableRenderer: true,
+		N:              10,
+		C:              1,
+	}
+	w.Run()
+
+	if bitmap != (1<<uint(w.N))-1 {
+		t.Errorf("Expected %d bits, found %x", w.N, bitmap)
+	}
+}


### PR DESCRIPTION
cc @segmentio/schema 

Added "-X" flag for dynamic HTTP request body generation. E.g.:

Template: test.json
```
{
  "id": "smoke-{{int}}",
  "time": "{{datetime}}",
}
```

`# hey -a foo:bar -m POST -T "application/json" -D test.json -X -n 100000 -c 100 https://localhost`